### PR TITLE
Allow handling of list of values in the custom_context section of the config file

### DIFF
--- a/aws_iam_tester/lib/aws_iam_tester.py
+++ b/aws_iam_tester/lib/aws_iam_tester.py
@@ -233,7 +233,10 @@ class AwsIamTester():
 
                     # the ContextKeyValues should be a list
                     if new_key == 'ContextKeyValues':
-                        result[new_key] = [value]
+                        if isinstance(value, list):
+                            result[new_key] = value
+                        else:    
+                         result[new_key] = [value]
                 else:
                     result[key] = value
 


### PR DESCRIPTION
… config file

Allow handling of list of values in the custom_context section of the config file The current version of the tool assumes single value strings in the context_key_values field and converts them into a list of one value, this PR checks for the type of the field and passes through the list of strings when needed

Example: 

```
### EC2
- actions: 
  - "ec2:StartInstances"
  - "ec2:StopInstances"
  expected_result: succeed
  resources: 
  - "arn:aws:ec2:eu-west-2:{account_id}:instance/*"
  custom_context: 
    - context_key_name: aws:ResourceTag/user:Stack
      context_key_values: 
       - dev
       - staging 
      context_key_type: stringList